### PR TITLE
Switch CLI from argparse to click

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -53,7 +53,7 @@ Either way, running `clai` will start an interactive session where you can chat 
 ## Help
 
 ```
-usage: clai [-h] [-m [MODEL]] [-a AGENT] [-l] [-t [CODE_THEME]] [--no-stream] [--version] [prompt]
+Usage: clai [OPTIONS] [PROMPT]
 
 PydanticAI CLI v...
 
@@ -62,18 +62,13 @@ Special prompts:
 * `/markdown` - show the last markdown output of the last question
 * `/multiline` - toggle multiline mode
 
-positional arguments:
-  prompt                AI Prompt, if omitted fall into interactive mode
-
-options:
-  -h, --help            show this help message and exit
-  -m [MODEL], --model [MODEL]
-                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o" or "anthropic:claude-3-7-sonnet-latest". Defaults to "openai:gpt-4o".
-  -a AGENT, --agent AGENT
-                        Custom Agent to use, in format "module:variable", e.g. "mymodule.submodule:my_agent"
-  -l, --list-models     List all available models and exit
-  -t [CODE_THEME], --code-theme [CODE_THEME]
-                        Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
-  --no-stream           Disable streaming from the model
-  --version             Show version and exit
+Options:
+  -m, --model MODEL   Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o" or "anthropic:claude-3-7-sonnet-latest". Defaults to "openai:gpt-4o".
+  -a, --agent AGENT   Custom Agent to use, in format "module:variable", e.g. "mymodule.submodule:my_agent"
+  -l, --list-models   List all available models and exit
+  -t, --code-theme TEXT
+                      Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
+  --no-stream         Disable streaming from the model
+  --version           Show version and exit
+  -h, --help          Show this message and exit.
 ```

--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import argparse
 import asyncio
 import importlib
 import os
@@ -14,6 +13,8 @@ from typing import Any, cast
 
 from typing_inspection.introspection import get_literal_values
 
+import click
+
 from pydantic_ai.result import OutputDataT
 from pydantic_ai.tools import AgentDepsT
 
@@ -24,7 +25,6 @@ from .messages import ModelMessage
 from .models import KnownModelName, infer_model
 
 try:
-    import argcomplete
     from prompt_toolkit import PromptSession
     from prompt_toolkit.auto_suggest import AutoSuggestFromHistory, Suggestion
     from prompt_toolkit.buffer import Buffer
@@ -39,7 +39,7 @@ try:
     from rich.text import Text
 except ImportError as _import_error:
     raise ImportError(
-        'Please install `rich`, `prompt-toolkit` and `argcomplete` to use the PydanticAI CLI, '
+        'Please install `rich` and `prompt-toolkit` to use the PydanticAI CLI, '
         'you can use the `cli` optional group — `pip install "pydantic-ai-slim[cli]"`'
     ) from _import_error
 
@@ -102,119 +102,100 @@ def cli_exit(prog_name: str = 'pai'):  # pragma: no cover
     sys.exit(cli(prog_name=prog_name))
 
 
-def cli(args_list: Sequence[str] | None = None, *, prog_name: str = 'pai') -> int:  # noqa: C901
-    """Run the CLI and return the exit code for the process."""
-    parser = argparse.ArgumentParser(
-        prog=prog_name,
-        description=f"""\
-PydanticAI CLI v{__version__}\n\n
-
-Special prompts:
-* `/exit` - exit the interactive mode (ctrl-c and ctrl-d also work)
-* `/markdown` - show the last markdown output of the last question
-* `/multiline` - toggle multiline mode
-""",
-        formatter_class=argparse.RawTextHelpFormatter,
-    )
-    parser.add_argument('prompt', nargs='?', help='AI Prompt, if omitted fall into interactive mode')
-    arg = parser.add_argument(
-        '-m',
-        '--model',
-        nargs='?',
-        help='Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o" or "anthropic:claude-3-7-sonnet-latest". Defaults to "openai:gpt-4o".',
-    )
-    # we don't want to autocomplete or list models that don't include the provider,
-    # e.g. we want to show `openai:gpt-4o` but not `gpt-4o`
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("prompt", required=False)
+@click.option("-m", "--model", metavar="MODEL", help='Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o" or "anthropic:claude-3-7-sonnet-latest". Defaults to "openai:gpt-4o".')
+@click.option("-a", "--agent", metavar="AGENT", help='Custom Agent to use, in format "module:variable", e.g. "mymodule.submodule:my_agent"')
+@click.option("-l", "--list-models", is_flag=True, help="List all available models and exit")
+@click.option("-t", "--code-theme", default="dark", metavar="THEME", help='Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.')
+@click.option("--no-stream", is_flag=True, help="Disable streaming from the model")
+@click.option("--version", is_flag=True, help="Show version and exit")
+@click.pass_context
+def _click_cli(ctx: click.Context, prompt: str | None, model: str | None, agent: str | None, list_models: bool, code_theme: str, no_stream: bool, version: bool) -> None:
+    """Internal click command for the CLI."""
     qualified_model_names = [n for n in get_literal_values(KnownModelName.__value__) if ':' in n]
-    arg.completer = argcomplete.ChoicesCompleter(qualified_model_names)  # type: ignore[reportPrivateUsage]
-    parser.add_argument(
-        '-a',
-        '--agent',
-        help='Custom Agent to use, in format "module:variable", e.g. "mymodule.submodule:my_agent"',
-    )
-    parser.add_argument(
-        '-l',
-        '--list-models',
-        action='store_true',
-        help='List all available models and exit',
-    )
-    parser.add_argument(
-        '-t',
-        '--code-theme',
-        nargs='?',
-        help='Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.',
-        default='dark',
-    )
-    parser.add_argument('--no-stream', action='store_true', help='Disable streaming from the model')
-    parser.add_argument('--version', action='store_true', help='Show version and exit')
-
-    argcomplete.autocomplete(parser)
-    args = parser.parse_args(args_list)
-
     console = Console()
-    name_version = f'[green]{prog_name} - PydanticAI CLI v{__version__}[/green]'
-    if args.version:
+    prog_name = ctx.obj["prog_name"]
+    name_version = f"[green]{prog_name} - PydanticAI CLI v{__version__}[/green]"
+    if version:
         console.print(name_version, highlight=False)
-        return 0
-    if args.list_models:
-        console.print(f'{name_version}\n\n[green]Available models:[/green]')
-        for model in qualified_model_names:
-            console.print(f'  {model}', highlight=False)
-        return 0
+        ctx.exit(0)
+    if list_models:
+        console.print(f"{name_version}\n\n[green]Available models:[/green]")
+        for m in qualified_model_names:
+            console.print(f"  {m}", highlight=False)
+        ctx.exit(0)
 
-    agent: Agent[None, str] = cli_agent
-    if args.agent:
+    current_agent: Agent[None, str] = cli_agent
+    if agent:
         sys.path.append(os.getcwd())
         try:
-            module_path, variable_name = args.agent.split(':')
+            module_path, variable_name = agent.split(":")
         except ValueError:
             console.print('[red]Error: Agent must be specified in "module:variable" format[/red]')
-            return 1
-
+            ctx.exit(1)
         module = importlib.import_module(module_path)
-        agent = getattr(module, variable_name)
-        if not isinstance(agent, Agent):
-            console.print(f'[red]Error: {args.agent} is not an Agent instance[/red]')
-            return 1
+        current_agent = getattr(module, variable_name)
+        if not isinstance(current_agent, Agent):
+            console.print(f'[red]Error: {agent} is not an Agent instance[/red]')
+            ctx.exit(1)
 
-    model_arg_set = args.model is not None
-    if agent.model is None or model_arg_set:
+    model_arg_set = model is not None
+    if current_agent.model is None or model_arg_set:
         try:
-            agent.model = infer_model(args.model or 'openai:gpt-4o')
+            current_agent.model = infer_model(model or 'openai:gpt-4o')
         except UserError as e:
-            console.print(f'Error initializing [magenta]{args.model}[/magenta]:\n[red]{e}[/red]')
-            return 1
+            console.print(f'Error initializing [magenta]{model}[/magenta]:\n[red]{e}[/red]')
+            ctx.exit(1)
 
-    model_name = agent.model if isinstance(agent.model, str) else f'{agent.model.system}:{agent.model.model_name}'
-    if args.agent and model_arg_set:
+    model_name = current_agent.model if isinstance(current_agent.model, str) else f'{current_agent.model.system}:{current_agent.model.model_name}'
+    if agent and model_arg_set:
         console.print(
-            f'{name_version} using custom agent [magenta]{args.agent}[/magenta] with [magenta]{model_name}[/magenta]',
+            f'{name_version} using custom agent [magenta]{agent}[/magenta] with [magenta]{model_name}[/magenta]',
             highlight=False,
         )
-    elif args.agent:
-        console.print(f'{name_version} using custom agent [magenta]{args.agent}[/magenta]', highlight=False)
+    elif agent:
+        console.print(f'{name_version} using custom agent [magenta]{agent}[/magenta]', highlight=False)
     else:
         console.print(f'{name_version} with [magenta]{model_name}[/magenta]', highlight=False)
 
-    stream = not args.no_stream
-    if args.code_theme == 'light':
-        code_theme = 'default'
-    elif args.code_theme == 'dark':
-        code_theme = 'monokai'
+    stream = not no_stream
+    if code_theme == 'light':
+        theme = 'default'
+    elif code_theme == 'dark':
+        theme = 'monokai'
     else:
-        code_theme = args.code_theme  # pragma: no cover
+        theme = code_theme  # pragma: no cover
 
-    if prompt := cast(str, args.prompt):
+    if prompt:
         try:
-            asyncio.run(ask_agent(agent, prompt, stream, console, code_theme))
+            asyncio.run(ask_agent(current_agent, prompt, stream, console, theme))
         except KeyboardInterrupt:
             pass
-        return 0
+        ctx.exit(0)
 
     try:
-        return asyncio.run(run_chat(stream, agent, console, code_theme, prog_name))
+        exit_code = asyncio.run(run_chat(stream, current_agent, console, theme, prog_name))
     except KeyboardInterrupt:  # pragma: no cover
-        return 0
+        exit_code = 0
+    ctx.exit(exit_code)
+
+
+def cli(args_list: Sequence[str] | None = None, *, prog_name: str = 'pai') -> int:
+    """Run the CLI and return the exit code for the process."""
+
+    try:
+        _click_cli.main(
+            args=args_list or None,
+            prog_name=prog_name,
+            standalone_mode=False,
+            obj={'prog_name': prog_name},
+        )
+    except SystemExit as e:  # pragma: no cover - click uses SystemExit
+        return int(e.code)
+    return 0
+
+
 
 
 async def run_chat(

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -73,7 +73,7 @@ bedrock = ["boto3>=1.35.74"]
 duckduckgo = ["duckduckgo-search>=7.0.0"]
 tavily = ["tavily-python>=0.5.0"]
 # CLI
-cli = ["rich>=13", "prompt-toolkit>=3", "argcomplete>=3.5.0"]
+cli = ["rich>=13", "prompt-toolkit>=3", "click>=8.1"]
 # MCP
 mcp = ["mcp>=1.9.0; python_version >= '3.10'"]
 # Evals


### PR DESCRIPTION
## Summary
- replace `argparse` with `click` in the CLI
- drop `argcomplete` from optional dependencies
- update CLI help text in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_mock')*
- `pre-commit run --files clai/README.md pydantic_ai_slim/pydantic_ai/_cli.py pydantic_ai_slim/pyproject.toml` *(fails: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684285af6dc0832c850babb51d009b82